### PR TITLE
Removing type hint from CommandHandler

### DIFF
--- a/src/Handler/CommandHandler.php
+++ b/src/Handler/CommandHandler.php
@@ -2,12 +2,11 @@
 
 namespace SimpleBus\Command\Handler;
 
-use SimpleBus\Command\Command;
-
 interface CommandHandler
 {
     /**
+     * @param $command
      * @return void
      */
-    public function handle(Command $command);
+    public function handle($command);
 }


### PR DESCRIPTION
Hear me out..

I'm working on an example hexagonal app using commands and handlers. I wanted to introduce a command bus into the equation and liked the look of this.

One of the big concepts I want to put across in the application is the dependency rule and ensuring that we're only depending on inner dependencies. 

So I'm creating adapters for any outer dependency. Therefore to use this library, I have something that looks like the following:

Example Command:

``` php
<?php

namespace Jenko\House\Command;

use Jenko\House\Adapter\SimpleBusCommandAdapter;

final class EnterRoomCommand extends SimpleBusCommandAdapter
{
    const NAME = 'enter-room';

    public $house;
    public $room;
}
```

Notice it's extending the adapter, which looks like this:

``` php
<?php

namespace Jenko\House\Adapter;

use Jenko\House\Command\CommandInterface;
use SimpleBus\Command\Command;

abstract class SimpleBusCommandAdapter implements Command, CommandInterface
{
    /**
     * {@inheritdoc}
     */
    public function name()
    {
        return static::NAME;
    }
}
```

Pretty straight forward so far. So then I wanted to do a similar thing with handlers:

Example Handler:

``` php
<?php

namespace Jenko\House\Handler;

use Jenko\House\Adapter\SimpleBusHandlerAdapter;
use Jenko\House\Event\EventDispatcherInterface;
use Jenko\House\Factory\HomeAloneHouseFactory;
use Jenko\House\House;

final class EnterRoomHandler extends SimpleBusHandlerAdapter implements HandlerInterface
{
    /**
     * @var House $house
     */
    private $house;

    /**
     * @var EventDispatcherInterface
     */
    private $dispatcher;

    /**
     * @param EventDispatcherInterface $dispatcher
     */
    public function __construct(EventDispatcherInterface $dispatcher)
    {
        $this->house = HomeAloneHouseFactory::getHouse();
        $this->dispatcher = $dispatcher;
    }

    /**
     * @param $command
     * @return mixed|void
     */
    public function handle($command)
    {
        $house = $this->house->enterRoom($command->room);
        $this->dispatcher->dispatch($house->releaseEvents());
    }
}
```

The Adapter:

``` php
<?php

namespace Jenko\House\Adapter;

use Jenko\House\Handler\HandlerInterface;
use SimpleBus\Command\Command;
use SimpleBus\Command\Handler\CommandHandler;

abstract class SimpleBusHandlerAdapter implements CommandHandler, HandlerInterface
{
    /**
     * {@inheritdoc}
     */
    abstract public function handle(Command $command);
}
```

Now obviously this doesn't work because of the type hint for `Command`. As `SimpleBus\Command\Handler\CommandHandler` is expecting a `SimpleBus\Command\Command` instance, I must type hint for that in my handlers. Thus, coupling my handlers to the `SimpleBus\Command\Handler\CommandHandler`. Type hinting to my adapter doesn't work unfortunately, as the method signature must match exactly of the interface.

I'm unsure if the commands and handlers should be part of my domain or if they are deemed part of the infrastructure (where I care less about decoupling so much). 

So, sorry for the long PR, but I guess it's kind of an RFC with the following questions:
- Can we lose the type hint?
- Should I just not worry about decoupling my commands/handlers so much?
- Other?

I tried to look at what similar libraries do, but didn't come to any conclusion really. Broadway doesn't require a type hint (https://github.com/qandidate-labs/broadway/blob/master/src/Broadway/CommandHandling/CommandHandlerInterface.php) nor does (https://github.com/tabbi89/CommanderBundle/blob/master/Command/CommandHandlerInterface.php) but then other similar libs do so ¯_(ツ)_/¯
